### PR TITLE
allow raw key to be passed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,27 @@ pip install cloudfront-signed-cookies
 
 ```python
 from cloudfront_signed_cookies.signer import Signer
+import os
 
 def main():
+    """
+    Method #1
+    Allow the signer to read your key from a file
+    """
     signer: Signer = Signer(
         cloudfront_key_id="K36X4X2EO997HM",
-        priv_key_file="./certs/private_key.pem",
+        private_key="./certs/private_key.pem",
+    )
+
+    """
+    Method #2
+    Alternatively you can pass the raw contents of the key in from
+    something such as an environment variable, for container (Docker)
+    based usage
+    """
+    signer: Signer = Signer(
+        cloudfront_key_id="K36X4X2EO997HM",
+        private_key=os.environ.get("PRIVATE_KEY")
     )
 
     cookies: dict = signer.generate_cookies(

--- a/cloudfront_signed_cookies/cli/sign/__init__.py
+++ b/cloudfront_signed_cookies/cli/sign/__init__.py
@@ -20,10 +20,10 @@ def create_curl_command(url: str, cookies: dict):
 @click.option(
     "--priv-key",
     "-p",
-    "priv_key_file",
+    "private_key",
     type=str,
     required=True,
-    help="the path to the private key file",
+    help="the path to the private key file, or raw value of the private key",
 )
 @click.option(
     "--key-id",
@@ -44,7 +44,7 @@ def create_curl_command(url: str, cookies: dict):
 @click.pass_context
 def sign(
     ctx: click.Context,
-    priv_key_file: str,
+    private_key: str,
     key_id: str,
     resource: str,
     policy,
@@ -60,6 +60,6 @@ def sign(
     else:
         policy = {}
     cookies = Signer(
-        cloudfront_key_id=key_id, priv_key_file=priv_key_file
+        cloudfront_key_id=key_id, private_key=private_key
     ).generate_cookies(Resource=resource, Policy=policy, SecondsBeforeExpires=expires)
     create_curl_command(resource, cookies)

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from cloudfront_signed_cookies.signer import Signer
 if __name__ == "__main__":
     signer = Signer(
         cloudfront_key_id="K36X4X2EO997HM",
-        priv_key_file="./certs/private_key.pem",
+        private_key="./certs/private_key.pem",
     )
 
     cookies: dict = signer.generate_cookies(


### PR DESCRIPTION
To improve the usage of this for Docker containers, and to allow a more secure handling of private keys, allowing for the raw string of the private key to be passed into the Signer would really help. This would allow for the storage of the private key value to be placed in a secret store and passed into the container via something such as a Task Definition on AWS, or a pod template on a Kubernetes stack.